### PR TITLE
Removing string cast for chapter in spine

### DIFF
--- a/txt2epub/txt2epub.py
+++ b/txt2epub/txt2epub.py
@@ -46,7 +46,7 @@ class Txt2Epub:
         book.set_language(book_language)
 
         # create chapters
-        spine = ["nav"]
+        spine: list[str | epub.EpubHtml] = ["nav"]
         toc = []
         for chapter_id, chapter_content_full in enumerate(chapters):
             chapter_lines = chapter_content_full.split("\n")

--- a/txt2epub/txt2epub.py
+++ b/txt2epub/txt2epub.py
@@ -66,7 +66,7 @@ class Txt2Epub:
 
             # add chapter to the book and TOC
             book.add_item(chapter)
-            spine.append(str(chapter))
+            spine.append(chapter)
             toc.append(chapter)
 
         # update book spine and TOC


### PR DESCRIPTION
First of all, thanks for creating this library! First time doing open source so apologies if I am not following some convention, but I noticed when I tried to use the library the generated .epub file failed conversion in [Amazon's kindle previewer app](https://kdp.amazon.com/en_US/help/topic/G202131170) with the following error:

`E20004: the id in the spine does not match any item in the manifest: &lt;EpubHtml:chapter_0:chap_01.xhtml&gt;`

I found that removing the string cast on the spine list resolved the problem (bringing it in line with the [ebooklib example](https://github.com/aerkalov/ebooklib/blob/e96c5016ee469f68c178d1872fc9ea8e882adcaa/samples/01_basic_create/create.py#L80) but I wanted to understand why that string cast was there to begin with. If my change makes sense then I figure this PR can be a quick fix.

Sample text file I was using to do the testing: 
[test.txt](https://github.com/user-attachments/files/18406571/test.txt)

Thanks!